### PR TITLE
Add several improvements and bug fixes to the CSV code

### DIFF
--- a/app/Http/Controllers/CSVController.php
+++ b/app/Http/Controllers/CSVController.php
@@ -21,17 +21,7 @@ class CSVController extends Controller
 
         if ($file->isValid()) {
             $tb = new TransactionBuilder;
-            $csv = $tb->createFromFile($file);
-            /**
-             * @todo optimise: calling save on every model is probably
-             * inefficient
-             */
-            foreach ($csv as $currentTransaction) {
-                if (null === Transaction::where('transaction_hash', $currentTransaction->transaction_hash)->first()) {
-                    $currentTransaction->save();
-                }
-            }
-            dd($csv);
+            $tb->copyTransactionsFromCsvToDb($file);
         } else {
             die;
         }

--- a/app/Http/Controllers/CSVController.php
+++ b/app/Http/Controllers/CSVController.php
@@ -22,11 +22,14 @@ class CSVController extends Controller
             $csv = $tb->createFromFile($file);
             /**
              * @todo optimise: calling save on every model is probably
-             * inefficient (use findOrCreate?)
+             * inefficient
              */
             foreach ($csv as $currentTransaction) {
-                $currentTransaction->save();
+                if (null === Transaction::where('transaction_hash', $currentTransaction->transaction_hash)->first()) {
+                    $currentTransaction->save();
+                }
             }
+            dd($csv);
         } else {
             die;
         }

--- a/app/Http/Controllers/CSVController.php
+++ b/app/Http/Controllers/CSVController.php
@@ -22,7 +22,7 @@ class CSVController extends Controller
             $csv = $tb->createFromFile($file);
             /**
              * @todo optimise: calling save on every model is probably
-             * inefficient
+             * inefficient (use findOrCreate?)
              */
             foreach ($csv as $currentTransaction) {
                 $currentTransaction->save();

--- a/app/Transaction.php
+++ b/app/Transaction.php
@@ -19,25 +19,8 @@ class Transaction extends Model
 
     public $timestamps = false;
 
-    public function __construct(
-        $cashSpent,
-        $customerId,
-        $date,
-        $discountAmount,
-        $storeId,
-        $totalAmount,
-        $transactionType
-    )
-    {
-        $this->cash_spent = $cashSpent;
-        $this->customer_id = $customerId;
-        $this->date = $date;
-        $this->discount_amount = $discountAmount;
-        $this->store_id = $storeId;
-        $this->total_amount = $totalAmount;
-        $this->transaction_type = $transactionType;
-        $this->transaction_hash = hash('md5', "$cashSpent$customerId$date$discountAmount$storeId$totalAmount$transactionType");
-    }
+    public function __construct()
+    {}
 
     public function customer()
     {
@@ -47,5 +30,10 @@ class Transaction extends Model
     public function store()
     {
         $this->hasOne('App\Store');
+    }
+
+    public function updateTransactionHash()
+    {
+        $this->transaction_hash = hash('md5', ''.$this->cash_spent.$this->customer_id.$this->date.$this->discount_amount.$this->store_id.$this->total_amount.$this->transaction_type);        
     }
 }

--- a/app/Transaction.php
+++ b/app/Transaction.php
@@ -19,12 +19,6 @@ class Transaction extends Model
 
     public $timestamps = false;
 
-<<<<<<< HEAD
-    public function __construct()
-    {}
-
-=======
->>>>>>> master
     public function customer()
     {
         return $this->hasOne('App\Customer');

--- a/app/TransactionBuilder.php
+++ b/app/TransactionBuilder.php
@@ -29,10 +29,12 @@ class TransactionBuilder
     {
         $array = str_getcsv($line);
 
-        $date = $this->extractDate($array[0]);
+        $transaction = new Transaction;
+
+        $transaction->date = $this->extractDate($array[0]);
         // I assumed the store id in the model and the outlet reference in the
         // model are the same - LM.
-        $storeId = $array[2];
+        $transaction->store_id = $array[2];
 
         $customerReference = $array[5];
         $customer = Customer::where('customer_reference', $customerReference)->first();
@@ -42,23 +44,17 @@ class TransactionBuilder
             $customer->save();
         }
 
-        $transactionType = $array[6];
-        $cashSpent = $this->extractPrice($array[7]);
-        $discountAmount = $this->extractPrice($array[8]);
-        $totalAmount = $this->extractPrice($array[9]);
-
-        $transaction = new Transaction(
-            $cashSpent,
-            $customer->id,
-            $date,
-            $discountAmount,
-            $storeId,
-            $totalAmount,
-            $transactionType
-        );
         // echo '<pre>';
-        // var_dump($cashSpent);
+        // var_dump('yo');
         // echo '</pre>';
+        $transaction->customer_id = $customer->id;
+        $transaction->transaction_type = $array[6];
+        $transaction->cash_spent = $this->extractPrice($array[7]);
+        $transaction->discount_amount = $this->extractPrice($array[8]);
+        $transaction->total_amount = $this->extractPrice($array[9]);
+        $transaction->updateTransactionHash();
+
+
         return $transaction;
     }
 

--- a/app/TransactionBuilder.php
+++ b/app/TransactionBuilder.php
@@ -43,11 +43,7 @@ class TransactionBuilder
             $customer->customer_reference = $customerReference;
             $customer->save();
         }
-
-<<<<<<< HEAD
-        // echo '<pre>';
-        // var_dump('yo');
-        // echo '</pre>';
+        
         $transaction->customer_id = $customer->id;
         $transaction->transaction_type = $array[6];
         $transaction->cash_spent = $this->extractPrice($array[7]);
@@ -55,23 +51,6 @@ class TransactionBuilder
         $transaction->total_amount = $this->extractPrice($array[9]);
         $transaction->updateTransactionHash();
 
-=======
-        $transactionType = $array[6];
-        $cashSpent = $this->extractPrice($array[7]);
-        $discountAmount = $this->extractPrice($array[8]);
-        $totalAmount = $this->extractPrice($array[9]);
-
-        $transaction = Transaction::create([
-            'customer_id' => $customer->id,
-            'store_id' => $storeId,
-            'date' => $date,
-            'transaction_type' => $transactionType,
-            'cash_spent' => $cashSpent,
-            'discount_amount' => $discountAmount,
-            'total_amount' => $totalAmount,
-            'transaction_hash' => hash('md5', "$cashSpent$customer->id$date$discountAmount$storeId$totalAmount$transactionType"),
-        ]);
->>>>>>> master
 
         return $transaction;
     }

--- a/app/TransactionBuilder.php
+++ b/app/TransactionBuilder.php
@@ -100,8 +100,8 @@ class TransactionBuilder
     public function extractPrice(string $csvCell): float
     {
         $prices = array();
-        preg_match('/[0-9][.][0-9]{2}/', $csvCell, $prices);
-        if (1 === sizeof($prices)) {
+        preg_match('/\d(\.(\d)?(\d)?)?/', $csvCell, $prices);
+        if (sizeof($prices) > 0) {
             $price = floatval($prices[0]);
             $isPositive = strpos($csvCell, '-') === false;
             if (!$isPositive) {

--- a/app/TransactionFinder.php
+++ b/app/TransactionFinder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App;
+
+/**
+ * @see TransactionBuilderTest#getTransactionWithHash
+ */
+class TransactionFinder
+{
+    private $hash;
+
+    public function __construct(string $hash)
+    {
+        $this->hash = $hash;
+    }
+
+    public function isTransaction($transaction)
+    {
+        return $transaction->transaction_hash === $this->hash;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "filp/whoops": "~2.0",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
+        "phpunit/dbunit": "^3.0",
         "phpunit/phpunit": "^6.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a5ec124831a91c4cb0075b2eabee336",
+    "content-hash": "0313f9df7c8cd78724479cc131638096",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2784,6 +2784,58 @@
             "time": "2017-09-04T11:05:03+00:00"
         },
         {
+            "name": "phpunit/dbunit",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/dbunit.git",
+                "reference": "f2f8bec1d6ad7ad0bcdb47c1ed56d9d42d3e39ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/f2f8bec1d6ad7ad0bcdb47c1ed56d9d42d3e39ab",
+                "reference": "f2f8bec1d6ad7ad0bcdb47c1ed56d9d42d3e39ab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "ext-simplexml": "*",
+                "php": "^7.0",
+                "phpunit/phpunit": "^6.0",
+                "symfony/yaml": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHPUnit extension for database interaction testing",
+            "homepage": "https://github.com/sebastianbergmann/dbunit/",
+            "keywords": [
+                "database",
+                "testing",
+                "xunit"
+            ],
+            "time": "2017-02-03T08:50:36+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "5.2.2",
             "source": {
@@ -3734,6 +3786,61 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/CSV/TransactionBuilderTest.php
+++ b/tests/CSV/TransactionBuilderTest.php
@@ -2,17 +2,19 @@
 
 namespace Tests\CSV;
 
-use Tests\TestCase;
+use Tests\DatabaseTestCase;
 use App\Transaction;
 use App\TransactionBuilder;
+use App\TransactionFinder;
 
-class TransactionBuilderTest extends TestCase
+class TransactionBuilderTest extends DatabaseTestCase
 {
     private $tb;
 
     protected function setUp()
     {
         $this->tb = new TransactionBuilder;
+        parent::setUp();
     }
 
     /**
@@ -48,6 +50,26 @@ class TransactionBuilderTest extends TestCase
     }
 
     /**
+     * @dataProvider filePathsProvider
+     */
+    public function testCopyTransactionsFromCsvToDb($filePath)
+    {
+        $expected_transactions_n = 16;
+
+        $this->tb->copyTransactionsFromCsvToDb($filePath);
+        $transactions_collection = Transaction::all();
+        
+        $this->assertEquals($expected_transactions_n, sizeof($transactions_collection));
+        $this->assertEquals(0.50, $this->getTransactionWithHash($transactions_collection, 'fed4ad8118913b381f331464f307cb18')->total_amount);
+        $this->assertEquals(0.80, $this->getTransactionWithHash($transactions_collection, '54bd1daeef281a7177ddfed48e785fda')->cash_spent);
+        $this->assertEquals('239', $this->getTransactionWithHash($transactions_collection, '73772429cd3bca77fd0c3b6b8c2eff52')->store_id);
+        $this->assertEquals('9', $this->getTransactionWithHash($transactions_collection, '91d2379e3e69c6a4e6d500984ba43403')->customer_id);
+        $this->assertEquals('2015-08-25 12:49:44', $this->getTransactionWithHash($transactions_collection, 'db8f1d15adebfdb329094f7e3ef635d4')->date);
+        $this->assertEquals(0.00, $this->getTransactionWithHash($transactions_collection, '9d7bcf7dc6faec68447e5860f3115e50')->discount_amount);
+        $this->assertEquals('07c10a4486e18e9a9c53bbfbdb9f6256', $this->getTransactionWithHash($transactions_collection, '07c10a4486e18e9a9c53bbfbdb9f6256')->transaction_hash);
+    }
+
+    /**
      * @todo why isn't base_path() working?
      */
     public function filePathsProvider()
@@ -56,5 +78,11 @@ class TransactionBuilderTest extends TestCase
             [__DIR__.'/../../resources/csv/test.csv'],
             //[__DIR__.'/../../resources/csv/Disbursals.csv'],
         ];
+    }
+
+    private function getTransactionWithHash($collection, $hash): Transaction
+    {
+        $a = new TransactionFinder($hash);
+        return $collection->first(array($a, 'isTransaction'));
     }
 }

--- a/tests/CSV/TransactionBuilderTest.php
+++ b/tests/CSV/TransactionBuilderTest.php
@@ -38,13 +38,13 @@ class TransactionBuilderTest extends TestCase
     public function testTransactions()
     {
         $transactions = $this->tb->createFromFile(__DIR__.'/../../resources/csv/test.csv');
-        $this->assertEquals(4.00, $transactions['7f0ca892ffc2387d716511ee55cdc134']->totalAmount);
-        $this->assertEquals(-1.25, $transactions['84872a23509293c131a72d58d4a85f99']->cash_spent);
-        $this->assertEquals('238', $transactions['bb464bce73e4d50a16a4cf6da3812b92']->storeId);
-        $this->assertEquals('dusa-0046', $transactions['83c38ae916e5e4beafd7badf57721c9f']->customer_id);
-        $this->assertEquals('24/08/2015 12:07:34', $transactions['51327b0ec6301e1ca646f9c41cef7638']->date);
-        $this->assertEquals(0.00, $transactions['7f0ca892ffc2387d716511ee55cdc134']->discountAmount);
-        $this->assertEquals('3f4d83428e0dd53c4d4b311ee787bccc', $transactions['3f4d83428e0dd53c4d4b311ee787bccc']->transaction_hash);
+        $this->assertEquals(0.50, $transactions['fed4ad8118913b381f331464f307cb18']->total_amount);
+        $this->assertEquals(0.80, $transactions['54bd1daeef281a7177ddfed48e785fda']->cash_spent);
+        $this->assertEquals('239', $transactions['73772429cd3bca77fd0c3b6b8c2eff52']->store_id);
+        $this->assertEquals('9', $transactions['91d2379e3e69c6a4e6d500984ba43403']->customer_id);
+        $this->assertEquals('2015-08-25 12:49:44', $transactions['db8f1d15adebfdb329094f7e3ef635d4']->date);
+        $this->assertEquals(0.00, $transactions['9d7bcf7dc6faec68447e5860f3115e50']->discount_amount);
+        $this->assertEquals('07c10a4486e18e9a9c53bbfbdb9f6256', $transactions['07c10a4486e18e9a9c53bbfbdb9f6256']->transaction_hash);
     }
 
     /**

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
+
+namespace Tests;
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\DbUnit\TestCaseTrait;
 
-abstract class Generic_Tests_DatabaseTestCase extends TestCase
+abstract class DatabaseTestCase extends TestCase
 {
     use TestCaseTrait;
 
@@ -16,7 +19,7 @@ abstract class Generic_Tests_DatabaseTestCase extends TestCase
     {
         if ($this->conn === null) {
             if (self::$pdo == null) {
-                self::$pdo = new PDO( $GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD'] );
+                self::$pdo = new \PDO( $GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD'] );
             }
             $this->conn = $this->createDefaultDBConnection(self::$pdo, $GLOBALS['DB_DBNAME']);
         }

--- a/tests/Generic_Tests_DatabaseTestCase.php
+++ b/tests/Generic_Tests_DatabaseTestCase.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use PHPUnit\DbUnit\TestCaseTrait;
+
+abstract class Generic_Tests_DatabaseTestCase extends TestCase
+{
+    use TestCaseTrait;
+
+    // only instantiate pdo once for test clean-up/fixture load
+    static private $pdo = null;
+
+    // only instantiate PHPUnit_Extensions_Database_DB_IDatabaseConnection once per test
+    private $conn = null;
+
+    final public function getConnection()
+    {
+        if ($this->conn === null) {
+            if (self::$pdo == null) {
+                self::$pdo = new PDO( $GLOBALS['DB_DSN'], $GLOBALS['DB_USER'], $GLOBALS['DB_PASSWD'] );
+            }
+            $this->conn = $this->createDefaultDBConnection(self::$pdo, $GLOBALS['DB_DBNAME']);
+        }
+
+        return $this->conn;
+    }
+
+    public function getDataSet()
+    {
+        return $this->createFlatXmlDataSet('dataset.xml');
+    }
+}

--- a/tests/bootstrap_tests.php
+++ b/tests/bootstrap_tests.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Contracts\Console\Kernel;
+
+require_once(__DIR__.'/../vendor/autoload.php');
+$app = require_once(__DIR__.'/../bootstrap/app.php');
+$app->make(Kernel::class)->bootstrap();

--- a/tests/dataset.xml
+++ b/tests/dataset.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" ?>
 <dataset>
-    <transactions />
+    <transactions>
+        <column>id</column>
+        <column>customer_id</column>
+        <column>store_id</column>
+        <column>date</column>
+        <column>transaction_type</column>
+        <column>cash_spent</column>
+        <column>discount_amount</column>
+        <column>total_amount</column>
+        <column>transaction_hash</column>
+    </transactions>
 </dataset>

--- a/tests/dataset.xml
+++ b/tests/dataset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<dataset>
+    <transactions />
+</dataset>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="bootstrap_tests.php">
+  <php>
+        <var name="DB_DSN" value="mysql:dbname=homestead;host=localhost" />
+        <var name="DB_USER" value="root" />
+        <var name="DB_PASSWD" value="" />
+        <var name="DB_DBNAME" value="homestead" />
+    </php>
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap_tests.php">
+</phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="bootstrap_tests.php">
   <php>
+        <ini name="display_errors" value="true"/>
         <var name="DB_DSN" value="mysql:dbname=homestead;host=localhost" />
         <var name="DB_USER" value="root" />
         <var name="DB_PASSWD" value="" />
         <var name="DB_DBNAME" value="homestead" />
-    </php>
+</php>
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="bootstrap_tests.php">
+<phpunit bootstrap="bootstrap_tests.php" colors="true">
   <php>
         <ini name="display_errors" value="true"/>
         <var name="DB_DSN" value="mysql:dbname=homestead;host=localhost" />


### PR DESCRIPTION
Some prices were not recognised by the extractPrice method because of a different format (e.g. "1", "4.1"). They are now recognised as well. Some improvements can still be made to the extractPrice method as it uses regex (which is inefficient).
This branch also fixes memory overload when trying to extract and save in the database Transaction objects from large CSV files. In practice, processing the Disbursals.csv file takes a few hours at least, so the server won't allow such a file to be processed anyway.
Unit tests are improved and now check for the transactions saved in the database. However, running the TransactionBuilderTest unit test will erase any content in the Transactions table.
Duplicates are not inserted into the database thanks to the method firstOrCreate which is slightly more readable.

You can see the commits for more details.